### PR TITLE
Add frontend UI for admin page with routing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,7 +9,8 @@
       "version": "1.0.0",
       "dependencies": {
         "react": "^18.2.0",
-        "react-dom": "^18.2.0"
+        "react-dom": "^18.2.0",
+        "react-router-dom": "^6.22.0"
       },
       "devDependencies": {
         "@vitejs/plugin-react": "^4.2.1",
@@ -788,6 +789,14 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@remix-run/router": {
+      "version": "1.23.2",
+      "resolved": "https://registry.npmjs.org/@remix-run/router/-/router-1.23.2.tgz",
+      "integrity": "sha512-Ic6m2U/rMjTkhERIa/0ZtXJP17QUi2CbWE7cqx4J58M8aA3QTfW+2UlQ4psvTX9IO1RfNVhK3pcpdjej7L+t2w==",
+      "engines": {
+        "node": ">=14.0.0"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -1581,6 +1590,36 @@
       "license": "MIT",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/react-router": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router/-/react-router-6.30.3.tgz",
+      "integrity": "sha512-XRnlbKMTmktBkjCLE8/XcZFlnHvr2Ltdr1eJX4idL55/9BbORzyZEaIkBFDhFGCEWBBItsVrDxwx3gnisMitdw==",
+      "dependencies": {
+        "@remix-run/router": "1.23.2"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8"
+      }
+    },
+    "node_modules/react-router-dom": {
+      "version": "6.30.3",
+      "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.30.3.tgz",
+      "integrity": "sha512-pxPcv1AczD4vso7G4Z3TKcvlxK7g7TNt3/FNGMhfqyntocvYKj+GCatfigGDjbLozC4baguJ0ReCigoDJXb0ag==",
+      "dependencies": {
+        "@remix-run/router": "1.23.2",
+        "react-router": "6.30.3"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "peerDependencies": {
+        "react": ">=16.8",
+        "react-dom": ">=16.8"
       }
     },
     "node_modules/rollup": {

--- a/package.json
+++ b/package.json
@@ -10,7 +10,8 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "react-router-dom": "^6.22.0"
   },
   "devDependencies": {
     "@vitejs/plugin-react": "^4.2.1",

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -1,37 +1,47 @@
+import { Routes, Route } from 'react-router-dom'
 import Header from './components/Header/Header'
 import AboutSection from './components/AboutSection/AboutSection'
 import RecentListingsSection from './components/RecentListings/RecentListingsSection'
 import SubleaseListings from './components/SubleaseListings/SubleaseListings'
 import ScraperSection from './components/ScraperSection/ScraperSection'
 import Footer from './components/Footer/Footer'
+import AdminUsersPage from './components/AdminUsersPage/AdminUsersPage'
 import './App.css'
+
+function HomePage() {
+  return (
+    <main className="main-content">
+      <section id="about">
+        <AboutSection />
+      </section>
+
+      <section id="listings">
+        <RecentListingsSection />
+      </section>
+
+      <section id="sublease">
+        <SubleaseListings />
+      </section>
+
+      <section id="scraper">
+        <ScraperSection />
+      </section>
+
+      <section id="contact">
+        <Footer />
+      </section>
+    </main>
+  )
+}
 
 function App() {
   return (
     <div className="app">
       <Header />
-
-      <main className="main-content">
-        <section id="about">
-          <AboutSection />
-        </section>
-
-        <section id="listings">
-          <RecentListingsSection />
-        </section>
-
-        <section id="sublease">
-          <SubleaseListings />
-        </section>
-
-        <section id="scraper">
-          <ScraperSection />
-        </section>
-
-        <section id="contact">
-          <Footer />
-        </section>
-      </main>
+      <Routes>
+        <Route path="/" element={<HomePage />} />
+        <Route path="/admin/users" element={<AdminUsersPage />} />
+      </Routes>
     </div>
   )
 }

--- a/src/components/AdminUsersPage/AdminUsersPage.css
+++ b/src/components/AdminUsersPage/AdminUsersPage.css
@@ -1,0 +1,100 @@
+.admin-page {
+  padding-top: calc(var(--header-height) + var(--spacing-lg));
+  padding-bottom: var(--spacing-xl);
+  min-height: 100vh;
+  background-color: var(--color-background-alt);
+}
+
+.admin-container {
+  max-width: var(--max-width);
+  margin: 0 auto;
+  padding: 0 var(--spacing-md);
+}
+
+.admin-title {
+  font-size: var(--font-size-2xl);
+  color: var(--color-text);
+  margin-bottom: var(--spacing-md);
+}
+
+.admin-empty {
+  color: var(--color-text-light);
+  font-size: var(--font-size-lg);
+  text-align: center;
+  padding: var(--spacing-xl) 0;
+}
+
+.admin-table-wrapper {
+  overflow-x: auto;
+}
+
+.admin-table {
+  width: 100%;
+  border-collapse: collapse;
+  background-color: var(--color-background);
+  border-radius: 8px;
+  overflow: hidden;
+  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.1);
+}
+
+.admin-table th,
+.admin-table td {
+  text-align: left;
+  padding: var(--spacing-sm) var(--spacing-md);
+  border-bottom: 1px solid var(--color-border);
+}
+
+.admin-table th {
+  background-color: var(--color-background-alt);
+  font-size: var(--font-size-sm);
+  font-weight: 600;
+  color: var(--color-text-light);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+
+.admin-table tbody tr:hover {
+  background-color: var(--color-background-alt);
+}
+
+.admin-table tbody tr:last-child td {
+  border-bottom: none;
+}
+
+.admin-role-badge {
+  display: inline-block;
+  padding: 2px 10px;
+  border-radius: 12px;
+  font-size: var(--font-size-sm);
+  font-weight: 500;
+}
+
+.admin-role-admin {
+  background-color: #dbeafe;
+  color: #1e40af;
+}
+
+.admin-role-user {
+  background-color: #f3f4f6;
+  color: var(--color-text-light);
+}
+
+@media (max-width: 600px) {
+  .admin-page {
+    padding-top: calc(var(--header-height) + var(--spacing-md));
+  }
+
+  .admin-container {
+    padding: 0 var(--spacing-sm);
+  }
+
+  .admin-title {
+    font-size: var(--font-size-xl);
+  }
+
+  .admin-table th,
+  .admin-table td {
+    padding: var(--spacing-xs) var(--spacing-sm);
+    font-size: var(--font-size-sm);
+  }
+}

--- a/src/components/AdminUsersPage/AdminUsersPage.jsx
+++ b/src/components/AdminUsersPage/AdminUsersPage.jsx
@@ -1,0 +1,65 @@
+import { useState } from 'react';
+import './AdminUsersPage.css';
+
+// Mock data — replace with API calls once the backend is implemented
+const MOCK_USERS = [
+  { id: 1, email: 'admin@ucsb.edu', role: 'admin', createdAt: '2026-01-10' },
+  { id: 2, email: 'johndoe@ucsb.edu', role: 'user', createdAt: '2026-01-15' },
+  { id: 3, email: 'alicebob@ucsb.edu', role: 'admin', createdAt: '2026-02-01' },
+];
+
+// Hardcoded for now — will come from auth once backend exists
+const isAdmin = true;
+
+function AdminUsersPage() {
+  const [users] = useState(MOCK_USERS);
+
+  if (!isAdmin) {
+    return (
+      <main className="admin-page">
+        <div className="admin-container">
+          <h1 className="admin-title">Access Denied</h1>
+          <p className="admin-empty">You do not have permission to view this page.</p>
+        </div>
+      </main>
+    );
+  }
+
+  return (
+    <main className="admin-page">
+      <div className="admin-container">
+        <h1 className="admin-title">User Management</h1>
+        {users.length === 0 ? (
+          <p className="admin-empty">No users found.</p>
+        ) : (
+          <div className="admin-table-wrapper">
+            <table className="admin-table">
+              <thead>
+                <tr>
+                  <th>Email</th>
+                  <th>Role</th>
+                  <th>Created Date</th>
+                </tr>
+              </thead>
+              <tbody>
+                {users.map((user) => (
+                  <tr key={user.id}>
+                    <td>{user.email}</td>
+                    <td>
+                      <span className={`admin-role-badge admin-role-${user.role}`}>
+                        {user.role}
+                      </span>
+                    </td>
+                    <td>{new Date(user.createdAt).toLocaleDateString()}</td>
+                  </tr>
+                ))}
+              </tbody>
+            </table>
+          </div>
+        )}
+      </div>
+    </main>
+  );
+}
+
+export default AdminUsersPage;

--- a/src/components/Header/Header.css
+++ b/src/components/Header/Header.css
@@ -40,7 +40,8 @@
   transition: color 0.2s ease, background-color 0.2s ease;
 }
 
-.header-links a:hover {
+.header-links a:hover,
+.header-links a.active {
   color: var(--color-primary);
   background-color: var(--color-background-alt);
 }

--- a/src/components/Header/Header.jsx
+++ b/src/components/Header/Header.jsx
@@ -1,7 +1,12 @@
+import { Link, useLocation } from 'react-router-dom';
 import './Header.css';
 
 function Header() {
+  const location = useLocation();
+  const isHome = location.pathname === '/';
+
   const handleNavClick = (e, targetId) => {
+    if (!isHome) return; // Let the <a href> navigate to /#section
     e.preventDefault();
     const element = document.getElementById(targetId);
     if (element) {
@@ -18,27 +23,35 @@ function Header() {
   return (
     <header className="header">
       <nav className="header-nav">
-        <div className="header-brand">Housing Manager</div>
+        <Link to="/" className="header-brand">Housing Manager</Link>
         <ul className="header-links">
           <li>
-            <a href="#about" onClick={(e) => handleNavClick(e, 'about')}>
+            <a href={isHome ? '#about' : '/#about'} onClick={(e) => handleNavClick(e, 'about')}>
               About
             </a>
           </li>
           <li>
-            <a href="#listings" onClick={(e) => handleNavClick(e, 'listings')}>
+            <a href={isHome ? '#listings' : '/#listings'} onClick={(e) => handleNavClick(e, 'listings')}>
               Listings
             </a>
           </li>
           <li>
-            <a href="#sublease" onClick={(e) => handleNavClick(e, 'sublease')}>
+            <a href={isHome ? '#sublease' : '/#sublease'} onClick={(e) => handleNavClick(e, 'sublease')}>
               Sublease
             </a>
           </li>
           <li>
-            <a href="#contact" onClick={(e) => handleNavClick(e, 'contact')}>
+            <a href={isHome ? '#contact' : '/#contact'} onClick={(e) => handleNavClick(e, 'contact')}>
               Contact
             </a>
+          </li>
+          <li>
+            <Link
+              to="/admin/users"
+              className={location.pathname.startsWith('/admin') ? 'active' : ''}
+            >
+              Admin
+            </Link>
           </li>
         </ul>
         <button className="header-login-btn">Login</button>

--- a/src/main.jsx
+++ b/src/main.jsx
@@ -1,10 +1,13 @@
 import React from 'react'
 import ReactDOM from 'react-dom/client'
+import { BrowserRouter } from 'react-router-dom'
 import App from './App'
 import './index.css'
 
 ReactDOM.createRoot(document.getElementById('root')).render(
   <React.StrictMode>
-    <App />
+    <BrowserRouter>
+      <App />
+    </BrowserRouter>
   </React.StrictMode>,
 )


### PR DESCRIPTION
### Overview
Closes #63 

In this PR, we add an admin tab and page using react router.  Note that since login and database have not been implemented, I have used mock data and hardcoded some fake users.

### Testing
1. Click "Admin" tab. This should direct you to the admin page
<img width="1252" height="437" alt="image" src="https://github.com/user-attachments/assets/85f47c24-23fb-42cb-97fe-5195823d4a76" />

2. Click "Housing Manager" tab. This should direct you back to the home page.
3. Modify this line in **components/AdminUsersPage/AdminUsersPage.jsx**: `const isAdmin = true;` to `const isAdmin = false;`. The page should now be blocked.
4. Delete all `MOCK_USERS`. The page should now say "No users found"